### PR TITLE
Fix build errors with vpp-18.07

### DIFF
--- a/srvpp/src/CMakeLists.txt
+++ b/srvpp/src/CMakeLists.txt
@@ -27,7 +27,7 @@ set(SRVPP_HEADERS
 )
 
 # libraries to link with
-set(LINK_LIBRARIES vlibmemoryclient vlibapi svm vppinfra pthread rt dl)
+set(LINK_LIBRARIES vlibmemoryclient svm vppinfra pthread rt dl)
 
 # build instructions
 add_library(srvpp SHARED ${SRVPP_SOURCES})

--- a/srvpp/src/srvpp.c
+++ b/srvpp/src/srvpp.c
@@ -22,7 +22,7 @@
 #include "srvpp_logger.h"
 
 #define vl_api_version(n,v) static u32 vpe_api_version = (v);
-#include <vpp-api/vpe.api.h>
+#include <vpp/api/vpe.api.h>
 #undef vl_api_version
 
 #define SRVPP_RESPONSE_TIMEOUT 2 /**< Maximum time (in seconds) that a client waits for the response(s) to a request or dumprequest. */

--- a/srvpp/src/srvpp.h
+++ b/srvpp/src/srvpp.h
@@ -32,18 +32,18 @@
 #include <vlibapi/api.h>
 #include <vlibmemory/api.h>
 
-#include <vpp-api/vpe_msg_enum.h>
+#include <vpp/api/vpe_msg_enum.h>
 #define vl_typedefs
-#include <vpp-api/vpe_all_api_h.h>
+#include <vpp/api/vpe_all_api_h.h>
 #undef vl_typedefs
 
 #define vl_endianfun
-#include <vpp-api/vpe_all_api_h.h>
+#include <vpp/api/vpe_all_api_h.h>
 #undef vl_endianfun
 
 #define vl_print(handle, ...)
 #define vl_printfun
-#include <vpp-api/vpe_all_api_h.h>
+#include <vpp/api/vpe_all_api_h.h>
 #undef vl_printfun
 
 /**


### PR DESCRIPTION
1. remove vlibapi since it was removed in vpp-18.07;
2. change vpp-api to vpp/api since it was changed in vpp-18.07